### PR TITLE
Fix sources attr type of assign method

### DIFF
--- a/src/js/Object.hx
+++ b/src/js/Object.hx
@@ -55,7 +55,7 @@ extern class Object {
 
 	  See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
 	*/
-	static function assign<TSource:JsObject, TDest:JsObject>(target:TSource, sources:Rest<{}>):TDest;
+	static function assign<TSource:JsObject, TDest:JsObject>(target:TSource, sources:Rest<JsObject>):TDest;
 
 	/**
 	  The Object.create() method create a new object, using an existing object


### PR DESCRIPTION
Needed if we have for example this below and we need to work with the `object_as_dynamic` flag:
```haxe 
var v : haxe.DynamicAccess<Int> = {};
// ...
var ww = js.Object.assign({},v);
```